### PR TITLE
Missing emacs-builds directory on a clean clone

### DIFF
--- a/build-emacs-from-bzr
+++ b/build-emacs-from-bzr
@@ -16,6 +16,8 @@ if [ ! -d emacs-bzr/trunk ]; then
     )
 fi
 
+mkdir -p emacs-builds
+
 (cd emacs-bzr/trunk
     OLDREV=$(bzr revno)
     bzr pull $REPO


### PR DESCRIPTION
Hi,

In this change the emacs-builds directory is created before performing the bzr checkout.

From the commit: "Without the directory the bzr build will tee to a non existing directory, subsequently the build will not happen."

I looked for a good place to put the statement, as it is in the build-emacs function, however I failed to find one so I added it the the bzr checkout script.

Hope this helps,

Arjen
