### PR TITLE
Gnu tar can lead to troubles

### DIFF
--- a/build-emacs-from-ftp
+++ b/build-emacs-from-ftp
@@ -40,7 +40,7 @@ DIR=${DIR%%.tar.xz}
 CAT=gzcat
 [[ $LATEST =~ \.xz$ ]] && CAT=xzcat
 
-$CAT ftp-versions/$LATEST | tar x -s ",^[^/]*,$DIR,"
+$CAT ftp-versions/$LATEST | /usr/bin/tar x -s ",^[^/]*,$DIR,"
 
 build_emacs "$DIR" "Emacs-${LABEL}$VERSION" || exit $?
 


### PR DESCRIPTION
Hey,

If a non bsd tar command gets in the path this command will fail. So this is just a very simple fix to make sure the bundled os x tar command will be used
