### PR TITLE
curl must not use locale to prevent from date parsing failures

### DIFF
--- a/build-emacs-from-ftp
+++ b/build-emacs-from-ftp
@@ -10,7 +10,7 @@ FTP_DIR_URL=${1:?"1st arg should be an ftp url"}
 LABEL=$2-
 LABEL=${LABEL#-}
 
-eval `curl -s "$FTP_DIR_URL/" | perl -MSort::Versions -ne 'push @v, { s=>$1, d=>$2, p=>$3, v=>$4 } if /(\d+) (\w+ \d+ (?: \d+|\d+:\d+)) (emacs-([\d.]+(?:-rc\d*|[a-z])?).tar.[xg]z)/; END { %r = %{${[sort { versioncmp $b->{v}, $a->{v} } @v]}[0]}; print "SIZE=$r{s}\nLATEST=$r{p}\nVERSION=$r{v}\nDATE=\"$r{d}\"\n" }'`
+eval `env LC_ALL=C curl -s "$FTP_DIR_URL/" | perl -MSort::Versions -ne 'push @v, { s=>$1, d=>$2, p=>$3, v=>$4 } if /(\d+) (\w+ \d+ (?: \d+|\d+:\d+)) (emacs-([\d.]+(?:-rc\d*|[a-z])?).tar.[xg]z)/; END { %r = %{${[sort { versioncmp $b->{v}, $a->{v} } @v]}[0]}; print "SIZE=$r{s}\nLATEST=$r{p}\nVERSION=$r{v}\nDATE=\"$r{d}\"\n" }'`
 
 # Prevent clean() from removing the whole directory when the above regular expression fails. Grrrrr.
 if [ x$LATEST = x ]; then


### PR DESCRIPTION
simple fix to force the usage of C locales to always get English dates perl can parse
