### PR TITLE
Enable Emacs 25 modules support

### DIFF
--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -78,6 +78,7 @@ options[:min_os] =  '10.7' if os_maj_version == '10.8'
 options[:min_os] =  '10.5' if os_maj_version == '10.6' && arch == :x86_64
 options[:min_os] =  '10.6' if trunk && options[:min_os] == '10.5'
 options[:extra_configure_flags] ||= []
+options[:extra_configure_flags] += %w"--with-modules"
 options[:extra_configure_flags] += %w"--with-jpeg=no --with-png=no --with-gif=no --with-tiff=no" if os_maj_version == '10.6'
 
 binary = build_emacs src_dir, "Emacs-#{label}#{version}-#{options[:min_os] || os_maj_version}-#{arch.to_s}", options


### PR DESCRIPTION
This PR adds the build flag necessary for Emacs 25 modules (FFI) support. 

It would be really nice to have an easily accessible Emacs version for OS X that has that feature.