### PR TITLE
Fix GitHub language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.r linguist-language=Rez


### PR DESCRIPTION
Specify that *.r stands for Rez source files.