### PR TITLE
Emacs 26.1.90 fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ the "xz" program on the machines that runs "fetch-emacs-from-ftp". The
 easiest way to get it is through [homebrew](http://brew.sh/): "brew install xz"
 
 
+### XCode Command Line Tools
+
+Building emacs requires that the XCode command line tools be installed so that
+some libraries (libxml2, at least) are available.
+
+    xcode-select --install
+
 Usage
 -----
 

--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -30,6 +30,8 @@ def build_emacs(src_dir, brew_dir, out_name, options={})
   ENV["PATH"]="#{brew_dir}/bin:#{ENV["PATH"]}"
 
   FileUtils.cd(src_dir) do
+    Vsh.system("if ! -f configure; then ./autogen.sh; fi")
+
     min_os_flag = options[:min_os] ? "-mmacosx-version-min=#{options[:min_os]}" : ""
     configure_flags = options[:host] ? ["--host=#{options[:host]}", '--build=i686-apple-darwin'] : []
     parallel_flags = options[:parallel] ? ["-j", options[:parallel]] : []

--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# coding: utf-8
 #  Copyright © 2014-2016 David Caldwell
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -87,7 +88,7 @@ def prepare_extra_deps(brew_dir, out_name, options)
   extra_source = "#{out_name}-extra-source"
   Vsh.rm_rf extra_source
   ensure_brew(brew_dir, %w(pkg-config), :gitrev => options[:brew_gitrev], :verbose => Vsh.verbose) # build deps
-  ensure_brew(brew_dir, %w(libtasn1 gmp nettle libunistring libffi) + [{'gnutls' => ['--without-p11-kit']}], # gnutls 3.5.18 is failing to compile with p11-kit, so dump it
+  ensure_brew(brew_dir, %w(libtasn1 gmp nettle libunistring libffi gnutls),
                                         :gitrev => options[:brew_gitrev], :get_source => extra_source, :verbose => Vsh.verbose,
                                         :extra_args=>['--build-bottle']) # build-bottle makes brew compile with -march=core2, which will let old hardware work.
   Vsh.system(*(%W"tar cf #{extra_source}.tar #{extra_source}"))

--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -40,6 +40,7 @@ def build_emacs(src_dir, brew_dir, out_name, options={})
     configure_flags += %W"--with-modules"
 
     ENV['CC']="#{options[:cc]} #{min_os_flag} #{options[:extra_cc_options]}"
+    ENV['LIBXML2_CFLAGS']="-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/libxml2"
     Vsh.system_trace(["CC=#{ENV['CC']}"])
     Vsh.system(*(%W"./configure --with-ns")+configure_flags+(options[:extra_configure_flags]||[]))
     Vsh.system(*(%W"make clean"))


### PR DESCRIPTION
The `build-emacs-from-tar` script failed to build emacs-26.1.90.tar.gz on my machine without the following changes.

* The tar file did not contain a pregenerated `configure` script so it was necessary to run `autogen.sh` to create it.
* Compiling the XML parser failed because the headers were not found. I set `LIBXML2_CFLAGS` when running configure to work around this problem. I see that the configure script has a macOS-specific test for libxml2 that looks like it should have worked, but it didn't.