### PR TITLE
Add ImageMagick support

### DIFF
--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -45,6 +45,7 @@ def build_emacs(src_dir, brew_dir, out_name, options={})
     Vsh.system(*(%W"make install"))
 
     copy_lib('nextstep/Emacs.app/Contents/MacOS/Emacs', brew_dir, "nextstep/Emacs.app/Contents/MacOS/#{options[:libdir]}") # Install and adjust libs into the App.
+    copy_imagemagick_modules('nextstep/Emacs.app/Contents/MacOS/Emacs', brew_dir, "nextstep/Emacs.app/Contents/MacOS/#{options[:libdir]}") # Install ImageMagick modules into the App.
 
     FileUtils.cd('nextstep') { Vsh.system(*(%W"tar cjf #{out_name} Emacs.app")) }
   end
@@ -80,13 +81,19 @@ def copy_lib(exe, brew_dir, dest, options={})
   end
 end
 
+def copy_imagemagick_modules(exe, brew_dir, dest, options={})
+  Vsh.cp_r(File.join(brew_dir, "lib/ImageMagick"), dest)
+end
+
 def prepare_extra_deps(brew_dir, out_name, options)
   extra_source = "#{out_name}-extra-source"
   Vsh.rm_rf extra_source
   ensure_brew(brew_dir, %w(pkg-config), :gitrev => options[:brew_gitrev], :verbose => Vsh.verbose) # build deps
-  ensure_brew(brew_dir, %w(libtasn1 gmp nettle libunistring libffi gnutls),
+  ensure_brew(brew_dir, %w(libtasn1 gmp nettle libunistring libffi gnutls imagemagick@6),
                                         :gitrev => options[:brew_gitrev], :get_source => extra_source, :verbose => Vsh.verbose,
                                         :extra_args=>['--build-bottle']) # build-bottle makes brew compile with -march=core2, which will let old hardware work.
+  link_in_brew(brew_dir, %w(imagemagick@6), :verbose => Vsh.verbose, # imagemagick@6 is keg-only, link it manually
+                                            :extra_args => ['--force'])
   Vsh.system(*(%W"tar cf #{extra_source}.tar #{extra_source}"))
   "#{extra_source}.tar"
 end

--- a/ensure-brew
+++ b/ensure-brew
@@ -64,6 +64,20 @@ def ensure_brew(dir, packages, options)
   end
 end
 
+def link_in_brew(dir, packages, options)
+  vsh = VerboseShell
+  vsh.verbose = options[:verbose]
+
+  FileUtils.cd(dir) do
+    with_env 'PATH' => "#{Dir.pwd}/bin:#{ENV['PATH']}" do
+      packages.each do |package|
+        extra_args = options[:extra_args] || []
+        vsh.system(*(%W"brew link #{package}" + extra_args))
+      end
+    end
+  end
+end
+
 if $0 == __FILE__
   gitrev = nil
   get_source = nil

--- a/launch.rb
+++ b/launch.rb
@@ -66,6 +66,11 @@ if emacs
   arch_version = emacs[:arch] + '-' + emacs[:_version] # see the 'combine-and-package' script in the build-emacs repo
   ENV['PATH'] += ':' + File.join(base_dir,     "bin-#{arch_version}") +
                  ':' + File.join(base_dir, "libexec-#{arch_version}")
+  # These environment variables are required for ImageMagick to successfully find it's modules
+  lib_dir = File.join(base_dir, "lib-#{arch_version}")
+  ENV['DYLD_LIBRARY_PATH'] = lib_dir
+  ENV['MAGICK_CONFIGURE_PATH'] = File.join(lib_dir, "ImageMagick/config-Q16")
+  ENV['MAGICK_CODER_MODULE_PATH'] = File.join(lib_dir, 'ImageMagick/modules-Q16/coders')
   exec [emacs[:exe], emacs[:exe]], *ARGV
 end
 


### PR DESCRIPTION
This PR adds ImageMagick support and fixes https://github.com/caldwell/build-emacs/issues/1.

Build script installs ImageMagick 6 dependency via brew and links it manually (because `imagemagick@6` is a keg-only formula and we don't need another `imagemagick` formula anyway).

Then copies shared libraries as usual and coders directory manually to the bundle.

To make lookup work I added three new environment variables to startup script (see this [SO question](https://stackoverflow.com/questions/16007654/imagemagick-deployment-on-mac-os)). But I'm not sure whether it's a good idea to set `DYLD_LIBRARY_PATH`.

Tested with `Mac OS 10.14.6`.