### PR TITLE
Keep up with Homebrew deprecation

### DIFF
--- a/brew-source.rb
+++ b/brew-source.rb
@@ -27,6 +27,6 @@ def fetch_source_and_deps(formula, dest)
 end
 
 ARGV.each do |package|
-  formula = Formulary.find_with_priority(package)
+  formula = Formulary.factory(package)
   fetch_source_and_deps(formula, dest)
 end


### PR DESCRIPTION
In https://github.com/Homebrew/brew/commit/4f75a77b089e65ff9e03c65d192808aa4ea6842f, a method was removed. 

It seems Formulary.find_with_priority is now deprecated. In the Homebrew commit,
they replaced callsites to use .factory instead. So I did that here. Seems to work
locally.

The reason for this change is I updated Homebrew and then tried to rebuild 
Emacs with jansson; it failed with:

```
Error: undefined method `find_with_priority' for Formulary:Module
.../build-emacs/brew/bin/brew-source.rb:30:in `block in <top (required)>'
```