### PR TITLE
decompress man page files

### DIFF
--- a/build-emacs-from-tar
+++ b/build-emacs-from-tar
@@ -46,6 +46,10 @@ def build_emacs(src_dir, brew_dir, out_name, options={})
 
     copy_lib('nextstep/Emacs.app/Contents/MacOS/Emacs', brew_dir, "nextstep/Emacs.app/Contents/MacOS/#{options[:libdir]}") # Install and adjust libs into the App.
 
+    Dir.glob("nextstep/Emacs.app/Contents/Resources/man/man1/*.gz") do |filename|
+      Vsh.system(*(%W"gunzip #{filename}"))
+    end
+
     FileUtils.cd('nextstep') { Vsh.system(*(%W"tar cjf #{out_name} Emacs.app")) }
   end
   Vsh.mv(File.join(src_dir, 'nextstep', out_name), out_name, :force => true)


### PR DESCRIPTION
Emacs's [Makefile](https://github.com/emacs-mirror/emacs/blob/a44d423a5aaf97790ce95350a38590fbb17b3220/Makefile.in#L681) compresses the man pages but Homebrew only supports the [decompressed](https://github.com/Homebrew/brew/blob/698c49067dbff69a44b13ab87c828d79a66dc543/Library/Homebrew/cask/artifact/manpage.rb#L15) man page file. This pull request decompress these files for Homebrew or other package managers to install manuals.

There are some argument errors about `FileUtils` functions in `verbose-shell.rb` on Ruby 3.0.0 but I'm not sure whether my fixes are suitable(remove `options` argument) so I don't include those commits here.

I also added GitHub action to build Emacs in my forked repo, I can send another pull request if you want it.